### PR TITLE
chore(guard): Refactor functions into enum / handle optional & no args

### DIFF
--- a/guard/resources/validate/functions/output/failing_join_show_summary_all.out
+++ b/guard/resources/validate/functions/output/failing_join_show_summary_all.out
@@ -25,7 +25,7 @@ Resource = newServer {
 
         }
       }
-      Check =  a,b EQUALS  (%collection,",") {
+      Check =  a,b EQUALS  join(%collection, ",") {
         ComparisonError {
           Message          = Violation: The joined value does not match the expected result
           Error            = Check was not compliant as property [/Resources/newServer/Collection/0[L:12,C:8]] was not present in [(resolved, Path=/Resources/newServer/Collection/0[L:12,C:8] Value="a,b,c")]

--- a/guard/resources/validate/functions/output/failing_join_show_summary_all.out
+++ b/guard/resources/validate/functions/output/failing_join_show_summary_all.out
@@ -25,7 +25,7 @@ Resource = newServer {
 
         }
       }
-      Check =  a,b EQUALS  join(%collection, ",") {
+      Check =  a,b EQUALS  (%collection,",") {
         ComparisonError {
           Message          = Violation: The joined value does not match the expected result
           Error            = Check was not compliant as property [/Resources/newServer/Collection/0[L:12,C:8]] was not present in [(resolved, Path=/Resources/newServer/Collection/0[L:12,C:8] Value="a,b,c")]

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -10,8 +10,7 @@ use crate::rules::functions::converters::{
 use crate::rules::functions::strings::{
     join, json_parse, regex_replace, substring, to_lower, to_upper, url_decode,
 };
-use crate::rules::path_value::Location;
-use crate::rules::path_value::{MapValue, PathAwareValue};
+use crate::rules::path_value::{Location, MapValue, PathAwareValue};
 use crate::rules::values::CmpOperator;
 use crate::rules::Result;
 use crate::rules::Status::SKIP;
@@ -24,8 +23,10 @@ use inflector::cases::*;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
+use std::convert::TryFrom;
 use std::rc::Rc;
 use std::vec::Vec;
+
 pub(crate) struct Scope<'value, 'loc: 'value> {
     root: Rc<PathAwareValue>,
     resolved_variables: HashMap<&'value str, Vec<QueryResult>>,
@@ -1174,22 +1175,74 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
     }
 }
 
-pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<()> {
-    let expected_num_args = match name {
-        "join" => 2,
-        "substring" | "regex_replace" => 3,
-        "count" | "json_parse" | "to_upper" | "to_lower" | "url_decode" | "parse_string"
-        | "parse_boolean" | "parse_float" | "parse_int" | "parse_char" => 1,
-        _ => {
-            return Err(Error::ParseError(format!(
-                "no such function named {name} exists"
-            )));
+#[derive(Debug)]
+pub(crate) enum Function {
+    Join,
+    Substring,
+    RegexReplace,
+    Count,
+    JsonParse,
+    ToUpper,
+    ToLower,
+    UrlDecode,
+    ParseString,
+    ParseBoolean,
+    ParseFloat,
+    ParseInt,
+    ParseChar,
+}
+
+impl TryFrom<&str> for Function {
+    type Error = Error;
+
+    fn try_from(name: &str) -> std::result::Result<Self, Self::Error> {
+        match name {
+            "join" => Ok(Function::Join),
+            "substring" => Ok(Function::Substring),
+            "regex_replace" => Ok(Function::RegexReplace),
+            "count" => Ok(Function::Count),
+            "json_parse" => Ok(Function::JsonParse),
+            "to_upper" => Ok(Function::ToUpper),
+            "to_lower" => Ok(Function::ToLower),
+            "url_decode" => Ok(Function::UrlDecode),
+            "parse_string" => Ok(Function::ParseString),
+            "parse_boolean" => Ok(Function::ParseBoolean),
+            "parse_float" => Ok(Function::ParseFloat),
+            "parse_int" => Ok(Function::ParseInt),
+            "parse_char" => Ok(Function::ParseChar),
+            _ => Err(Error::ParseError(format!(
+                "No function with the name '{name}' exists.",
+            ))),
         }
+    }
+}
+
+pub(crate) fn validate_number_of_params(func: &Function, num_args: usize) -> Result<()> {
+    let valid_num_args = match func {
+        Function::Join => vec![2],
+        Function::Substring | Function::RegexReplace => vec![3],
+        Function::Count
+        | Function::JsonParse
+        | Function::ToUpper
+        | Function::ToLower
+        | Function::UrlDecode
+        | Function::ParseString
+        | Function::ParseBoolean
+        | Function::ParseFloat
+        | Function::ParseInt
+        | Function::ParseChar => vec![1],
     };
 
-    if expected_num_args != num_args {
+    if !valid_num_args.contains(&num_args) {
         return Err(Error::ParseError(format!(
-            "{name} function requires {expected_num_args} arguments be passed, but received {num_args}"
+            "{:?} function requires {} arguments be passed, but received {}",
+            func,
+            if valid_num_args.len() == 1 {
+                valid_num_args[0].to_string()
+            } else {
+                format!("either {} or {}", valid_num_args[0], valid_num_args[1])
+            },
+            num_args
         )));
     }
 
@@ -1198,13 +1251,13 @@ pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<(
 
 // TODO: look into the possibility of abstracting functions into structs that all implement
 pub(crate) fn try_handle_function_call(
-    fn_name: &str,
+    func: Function,
     args: &[Vec<QueryResult>],
 ) -> Result<Vec<Option<PathAwareValue>>> {
-    let value = match fn_name {
-        "count" => vec![Some(count(&args[0]))],
-        "json_parse" => json_parse(&args[0])?,
-        "regex_replace" => {
+    let value = match func {
+        Function::Count => vec![Some(count(&args[0]))],
+        Function::JsonParse => json_parse(&args[0])?,
+        Function::RegexReplace => {
             let substring_err_msg = |index| {
                 let arg = match index {
                     2 => "second",
@@ -1233,7 +1286,7 @@ pub(crate) fn try_handle_function_call(
 
             regex_replace(&args[0], extracted_expr, replaced_expr)?
         }
-        "substring" => {
+        Function::Substring => {
             let substring_err_msg = |index| {
                 let arg = match index {
                     2 => "second",
@@ -1264,9 +1317,9 @@ pub(crate) fn try_handle_function_call(
 
             substring(&args[0], from, to)?
         }
-        "to_upper" => to_upper(&args[0])?,
-        "to_lower" => to_lower(&args[0])?,
-        "join" => {
+        Function::ToUpper => to_upper(&args[0])?,
+        Function::ToLower => to_lower(&args[0])?,
+        Function::Join => {
             let res = match &args[1][0] {
                 QueryResult::Resolved(r) | QueryResult::Literal(r) => match &**r {
                     PathAwareValue::String((_, s)) => join(&args[0], s),
@@ -1284,13 +1337,12 @@ pub(crate) fn try_handle_function_call(
 
             vec![Some(res)]
         }
-        "url_decode" => url_decode(&args[0])?,
-        "parse_int" => parse_int(&args[0])?,
-        "parse_float" => parse_float(&args[0])?,
-        "parse_string" => parse_str(&args[0])?,
-        "parse_boolean" => parse_bool(&args[0])?,
-        "parse_char" => parse_char(&args[0])?,
-        function => return Err(Error::ParseError(format!("No function named {function}"))),
+        Function::UrlDecode => url_decode(&args[0])?,
+        Function::ParseInt => parse_int(&args[0])?,
+        Function::ParseFloat => parse_float(&args[0])?,
+        Function::ParseString => parse_str(&args[0])?,
+        Function::ParseBoolean => parse_bool(&args[0])?,
+        Function::ParseChar => parse_char(&args[0])?,
     };
 
     Ok(value)
@@ -2266,7 +2318,8 @@ pub(crate) fn resolve_function<'value, 'eval, 'loc: 'value>(
     parameters: &'value [LetValue<'loc>],
     resolver: &'eval mut dyn EvalContext<'value, 'loc>,
 ) -> Result<Vec<QueryResult>> {
-    validate_number_of_params(name, parameters.len())?;
+    let func = Function::try_from(name)?;
+    validate_number_of_params(&func, parameters.len())?;
     let args =
         parameters
             .iter()
@@ -2290,7 +2343,7 @@ pub(crate) fn resolve_function<'value, 'eval, 'loc: 'value>(
                 Ok(args)
             })?;
 
-    Ok(try_handle_function_call(name, &args)?
+    Ok(try_handle_function_call(func, &args)?
         .into_iter()
         .flatten()
         .map(Rc::new)

--- a/guard/src/rules/eval_context_tests.rs
+++ b/guard/src/rules/eval_context_tests.rs
@@ -507,7 +507,7 @@ fn test_handle_function_call() -> Result<()> {
         vec![replaced.clone()],
     ];
 
-    let res = try_handle_function_call(&FunctionName::RegexReplace, &args)?;
+    let res = FunctionName::RegexReplace.call(&args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!("aws/123456789012/us-west-2/newservice-Table/extracted", val);
@@ -521,7 +521,7 @@ fn test_handle_function_call() -> Result<()> {
         query_results2,
         vec![replaced.clone()],
     ];
-    let res = try_handle_function_call(&FunctionName::RegexReplace, &args);
+    let res = FunctionName::RegexReplace.call(&args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -538,7 +538,7 @@ fn test_handle_function_call() -> Result<()> {
         vec![extracted.clone()],
         query_results2,
     ];
-    let res = try_handle_function_call(&FunctionName::RegexReplace, &args);
+    let res = FunctionName::RegexReplace.call(&args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -551,7 +551,7 @@ fn test_handle_function_call() -> Result<()> {
     let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
     let query_results2 = eval.query(&not_a_string)?;
     let args = vec![query_results2, vec![extracted.clone()], vec![replaced]];
-    let res = try_handle_function_call(&FunctionName::RegexReplace, &args)?;
+    let res = FunctionName::RegexReplace.call(&args)?;
     assert_eq!(res.len(), 1);
     assert!(res[0].is_none());
 
@@ -563,7 +563,7 @@ fn test_handle_function_call() -> Result<()> {
 
     // substring - happy path
     let args = vec![query_results.clone(), vec![from.clone()], vec![to.clone()]];
-    let res = try_handle_function_call(&FunctionName::Substring, &args)?;
+    let res = FunctionName::Substring.call(&args)?;
 
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
@@ -574,13 +574,13 @@ fn test_handle_function_call() -> Result<()> {
     let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
     let query_results2 = eval.query(&not_a_string)?;
     let args = vec![query_results2, vec![from.clone()], vec![to.clone()]];
-    let res = try_handle_function_call(&FunctionName::Substring, &args)?;
+    let res = FunctionName::Substring.call(&args)?;
     assert_eq!(res.len(), 1);
     assert!(res[0].is_none());
 
     // second argument is not a number
     let args = vec![query_results.clone(), vec![extracted.clone()], vec![to]];
-    let res = try_handle_function_call(&FunctionName::Substring, &args);
+    let res = FunctionName::Substring.call(&args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -591,7 +591,7 @@ fn test_handle_function_call() -> Result<()> {
 
     // third argument is not a number
     let args = vec![query_results.clone(), vec![from.clone()], vec![extracted]];
-    let res = try_handle_function_call(&FunctionName::Substring, &args);
+    let res = FunctionName::Substring.call(&args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -610,7 +610,7 @@ fn test_handle_function_call() -> Result<()> {
     let string_delim = QueryResult::Literal(Rc::new(string_delim_query));
 
     let args = vec![image_id_result.clone(), vec![char_delim]];
-    let res = try_handle_function_call(&FunctionName::Join, &args)?;
+    let res = FunctionName::Join.call(&args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!(
@@ -620,7 +620,7 @@ fn test_handle_function_call() -> Result<()> {
     }
 
     let args = vec![image_id_result.clone(), vec![string_delim]];
-    let res = try_handle_function_call(&FunctionName::Join, &args)?;
+    let res = FunctionName::Join.call(&args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!(
@@ -630,7 +630,7 @@ fn test_handle_function_call() -> Result<()> {
     }
 
     let args = vec![image_id_result, vec![from]];
-    let res = try_handle_function_call(&FunctionName::Join, &args);
+    let res = FunctionName::Join.call(&args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));

--- a/guard/src/rules/eval_context_tests.rs
+++ b/guard/src/rules/eval_context_tests.rs
@@ -507,7 +507,7 @@ fn test_handle_function_call() -> Result<()> {
         vec![replaced.clone()],
     ];
 
-    let res = try_handle_function_call(FunctionName::RegexReplace, &args)?;
+    let res = try_handle_function_call(&FunctionName::RegexReplace, &args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!("aws/123456789012/us-west-2/newservice-Table/extracted", val);
@@ -521,7 +521,7 @@ fn test_handle_function_call() -> Result<()> {
         query_results2,
         vec![replaced.clone()],
     ];
-    let res = try_handle_function_call(FunctionName::RegexReplace, &args);
+    let res = try_handle_function_call(&FunctionName::RegexReplace, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -538,7 +538,7 @@ fn test_handle_function_call() -> Result<()> {
         vec![extracted.clone()],
         query_results2,
     ];
-    let res = try_handle_function_call(FunctionName::RegexReplace, &args);
+    let res = try_handle_function_call(&FunctionName::RegexReplace, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -551,7 +551,7 @@ fn test_handle_function_call() -> Result<()> {
     let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
     let query_results2 = eval.query(&not_a_string)?;
     let args = vec![query_results2, vec![extracted.clone()], vec![replaced]];
-    let res = try_handle_function_call(FunctionName::RegexReplace, &args)?;
+    let res = try_handle_function_call(&FunctionName::RegexReplace, &args)?;
     assert_eq!(res.len(), 1);
     assert!(res[0].is_none());
 
@@ -563,7 +563,7 @@ fn test_handle_function_call() -> Result<()> {
 
     // substring - happy path
     let args = vec![query_results.clone(), vec![from.clone()], vec![to.clone()]];
-    let res = try_handle_function_call(FunctionName::Substring, &args)?;
+    let res = try_handle_function_call(&FunctionName::Substring, &args)?;
 
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
@@ -574,13 +574,13 @@ fn test_handle_function_call() -> Result<()> {
     let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
     let query_results2 = eval.query(&not_a_string)?;
     let args = vec![query_results2, vec![from.clone()], vec![to.clone()]];
-    let res = try_handle_function_call(FunctionName::Substring, &args)?;
+    let res = try_handle_function_call(&FunctionName::Substring, &args)?;
     assert_eq!(res.len(), 1);
     assert!(res[0].is_none());
 
     // second argument is not a number
     let args = vec![query_results.clone(), vec![extracted.clone()], vec![to]];
-    let res = try_handle_function_call(FunctionName::Substring, &args);
+    let res = try_handle_function_call(&FunctionName::Substring, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -591,7 +591,7 @@ fn test_handle_function_call() -> Result<()> {
 
     // third argument is not a number
     let args = vec![query_results.clone(), vec![from.clone()], vec![extracted]];
-    let res = try_handle_function_call(FunctionName::Substring, &args);
+    let res = try_handle_function_call(&FunctionName::Substring, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -610,7 +610,7 @@ fn test_handle_function_call() -> Result<()> {
     let string_delim = QueryResult::Literal(Rc::new(string_delim_query));
 
     let args = vec![image_id_result.clone(), vec![char_delim]];
-    let res = try_handle_function_call(FunctionName::Join, &args)?;
+    let res = try_handle_function_call(&FunctionName::Join, &args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!(
@@ -620,7 +620,7 @@ fn test_handle_function_call() -> Result<()> {
     }
 
     let args = vec![image_id_result.clone(), vec![string_delim]];
-    let res = try_handle_function_call(FunctionName::Join, &args)?;
+    let res = try_handle_function_call(&FunctionName::Join, &args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!(
@@ -630,7 +630,7 @@ fn test_handle_function_call() -> Result<()> {
     }
 
     let args = vec![image_id_result, vec![from]];
-    let res = try_handle_function_call(FunctionName::Join, &args);
+    let res = try_handle_function_call(&FunctionName::Join, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));

--- a/guard/src/rules/eval_context_tests.rs
+++ b/guard/src/rules/eval_context_tests.rs
@@ -507,7 +507,7 @@ fn test_handle_function_call() -> Result<()> {
         vec![replaced.clone()],
     ];
 
-    let res = try_handle_function_call(Function::RegexReplace, &args)?;
+    let res = try_handle_function_call(FunctionName::RegexReplace, &args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!("aws/123456789012/us-west-2/newservice-Table/extracted", val);
@@ -521,7 +521,7 @@ fn test_handle_function_call() -> Result<()> {
         query_results2,
         vec![replaced.clone()],
     ];
-    let res = try_handle_function_call(Function::RegexReplace, &args);
+    let res = try_handle_function_call(FunctionName::RegexReplace, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -538,7 +538,7 @@ fn test_handle_function_call() -> Result<()> {
         vec![extracted.clone()],
         query_results2,
     ];
-    let res = try_handle_function_call(Function::RegexReplace, &args);
+    let res = try_handle_function_call(FunctionName::RegexReplace, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -551,7 +551,7 @@ fn test_handle_function_call() -> Result<()> {
     let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
     let query_results2 = eval.query(&not_a_string)?;
     let args = vec![query_results2, vec![extracted.clone()], vec![replaced]];
-    let res = try_handle_function_call(Function::RegexReplace, &args)?;
+    let res = try_handle_function_call(FunctionName::RegexReplace, &args)?;
     assert_eq!(res.len(), 1);
     assert!(res[0].is_none());
 
@@ -563,7 +563,7 @@ fn test_handle_function_call() -> Result<()> {
 
     // substring - happy path
     let args = vec![query_results.clone(), vec![from.clone()], vec![to.clone()]];
-    let res = try_handle_function_call(Function::Substring, &args)?;
+    let res = try_handle_function_call(FunctionName::Substring, &args)?;
 
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
@@ -574,13 +574,13 @@ fn test_handle_function_call() -> Result<()> {
     let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
     let query_results2 = eval.query(&not_a_string)?;
     let args = vec![query_results2, vec![from.clone()], vec![to.clone()]];
-    let res = try_handle_function_call(Function::Substring, &args)?;
+    let res = try_handle_function_call(FunctionName::Substring, &args)?;
     assert_eq!(res.len(), 1);
     assert!(res[0].is_none());
 
     // second argument is not a number
     let args = vec![query_results.clone(), vec![extracted.clone()], vec![to]];
-    let res = try_handle_function_call(Function::Substring, &args);
+    let res = try_handle_function_call(FunctionName::Substring, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -591,23 +591,13 @@ fn test_handle_function_call() -> Result<()> {
 
     // third argument is not a number
     let args = vec![query_results.clone(), vec![from.clone()], vec![extracted]];
-    let res = try_handle_function_call(Function::Substring, &args);
+    let res = try_handle_function_call(FunctionName::Substring, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
     assert_eq!(
         err.to_string(),
         String::from("Parser Error when parsing `substring function requires the third argument to be a number`")
-    );
-
-    // invalid fn name
-    let res = try_handle_function_call(Function::try_from("fn")?, &[query_results]);
-    assert!(res.is_err());
-    let err = res.unwrap_err();
-    assert!(matches!(err, Error::ParseError(_)));
-    assert_eq!(
-        err.to_string(),
-        String::from("Parser Error when parsing `No function named fn`")
     );
 
     // join happy path
@@ -620,7 +610,7 @@ fn test_handle_function_call() -> Result<()> {
     let string_delim = QueryResult::Literal(Rc::new(string_delim_query));
 
     let args = vec![image_id_result.clone(), vec![char_delim]];
-    let res = try_handle_function_call(Function::Join, &args)?;
+    let res = try_handle_function_call(FunctionName::Join, &args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!(
@@ -630,7 +620,7 @@ fn test_handle_function_call() -> Result<()> {
     }
 
     let args = vec![image_id_result.clone(), vec![string_delim]];
-    let res = try_handle_function_call(Function::Join, &args)?;
+    let res = try_handle_function_call(FunctionName::Join, &args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!(
@@ -640,7 +630,7 @@ fn test_handle_function_call() -> Result<()> {
     }
 
     let args = vec![image_id_result, vec![from]];
-    let res = try_handle_function_call(Function::Join, &args);
+    let res = try_handle_function_call(FunctionName::Join, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));

--- a/guard/src/rules/eval_context_tests.rs
+++ b/guard/src/rules/eval_context_tests.rs
@@ -507,7 +507,7 @@ fn test_handle_function_call() -> Result<()> {
         vec![replaced.clone()],
     ];
 
-    let res = try_handle_function_call("regex_replace", &args)?;
+    let res = try_handle_function_call(Function::RegexReplace, &args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!("aws/123456789012/us-west-2/newservice-Table/extracted", val);
@@ -521,7 +521,7 @@ fn test_handle_function_call() -> Result<()> {
         query_results2,
         vec![replaced.clone()],
     ];
-    let res = try_handle_function_call("regex_replace", &args);
+    let res = try_handle_function_call(Function::RegexReplace, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -538,7 +538,7 @@ fn test_handle_function_call() -> Result<()> {
         vec![extracted.clone()],
         query_results2,
     ];
-    let res = try_handle_function_call("regex_replace", &args);
+    let res = try_handle_function_call(Function::RegexReplace, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -551,7 +551,7 @@ fn test_handle_function_call() -> Result<()> {
     let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
     let query_results2 = eval.query(&not_a_string)?;
     let args = vec![query_results2, vec![extracted.clone()], vec![replaced]];
-    let res = try_handle_function_call("regex_replace", &args)?;
+    let res = try_handle_function_call(Function::RegexReplace, &args)?;
     assert_eq!(res.len(), 1);
     assert!(res[0].is_none());
 
@@ -563,7 +563,7 @@ fn test_handle_function_call() -> Result<()> {
 
     // substring - happy path
     let args = vec![query_results.clone(), vec![from.clone()], vec![to.clone()]];
-    let res = try_handle_function_call("substring", &args)?;
+    let res = try_handle_function_call(Function::Substring, &args)?;
 
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
@@ -574,13 +574,13 @@ fn test_handle_function_call() -> Result<()> {
     let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
     let query_results2 = eval.query(&not_a_string)?;
     let args = vec![query_results2, vec![from.clone()], vec![to.clone()]];
-    let res = try_handle_function_call("substring", &args)?;
+    let res = try_handle_function_call(Function::Substring, &args)?;
     assert_eq!(res.len(), 1);
     assert!(res[0].is_none());
 
     // second argument is not a number
     let args = vec![query_results.clone(), vec![extracted.clone()], vec![to]];
-    let res = try_handle_function_call("substring", &args);
+    let res = try_handle_function_call(Function::Substring, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -591,7 +591,7 @@ fn test_handle_function_call() -> Result<()> {
 
     // third argument is not a number
     let args = vec![query_results.clone(), vec![from.clone()], vec![extracted]];
-    let res = try_handle_function_call("substring", &args);
+    let res = try_handle_function_call(Function::Substring, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -601,7 +601,7 @@ fn test_handle_function_call() -> Result<()> {
     );
 
     // invalid fn name
-    let res = try_handle_function_call("fn", &[query_results]);
+    let res = try_handle_function_call(Function::try_from("fn")?, &[query_results]);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));
@@ -620,7 +620,7 @@ fn test_handle_function_call() -> Result<()> {
     let string_delim = QueryResult::Literal(Rc::new(string_delim_query));
 
     let args = vec![image_id_result.clone(), vec![char_delim]];
-    let res = try_handle_function_call("join", &args)?;
+    let res = try_handle_function_call(Function::Join, &args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!(
@@ -630,7 +630,7 @@ fn test_handle_function_call() -> Result<()> {
     }
 
     let args = vec![image_id_result.clone(), vec![string_delim]];
-    let res = try_handle_function_call("join", &args)?;
+    let res = try_handle_function_call(Function::Join, &args)?;
     let path_value = res[0].as_ref().unwrap();
     if let PathAwareValue::String((_, val)) = path_value {
         assert_eq!(
@@ -640,7 +640,7 @@ fn test_handle_function_call() -> Result<()> {
     }
 
     let args = vec![image_id_result, vec![from]];
-    let res = try_handle_function_call("join", &args);
+    let res = try_handle_function_call(Function::Join, &args);
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert!(matches!(err, Error::ParseError(_)));

--- a/guard/src/rules/exprs.rs
+++ b/guard/src/rules/exprs.rs
@@ -7,6 +7,8 @@ use std::fmt::Formatter;
 use std::hash::Hash;
 use std::rc::Rc;
 
+use super::eval_context::FunctionName;
+
 #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
 pub(crate) struct FileLocation<'loc> {
     pub(crate) line: u32,
@@ -215,7 +217,7 @@ pub(crate) struct ParameterizedNamedRuleClause<'loc> {
 #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
 pub(crate) struct FunctionExpr<'loc> {
     pub(crate) parameters: Vec<LetValue<'loc>>,
-    pub(crate) name: String,
+    pub(crate) name: FunctionName,
     pub(crate) location: FileLocation<'loc>,
 }
 
@@ -369,8 +371,8 @@ impl<'loc> std::fmt::Display for FunctionExpr<'loc> {
             .iter()
             .map(|each| each.to_string())
             .collect::<Vec<_>>()
-            .join(",");
-        write!(f, "({})", params)
+            .join(", ");
+        write!(f, "{}({})", &self.name, params)
     }
 }
 

--- a/guard/src/rules/exprs.rs
+++ b/guard/src/rules/exprs.rs
@@ -364,15 +364,13 @@ impl<'loc> std::fmt::Display for AccessQuery<'loc> {
 
 impl<'loc> std::fmt::Display for FunctionExpr<'loc> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}(", self.name)?;
-        let last_index = self.parameters.len() - 1;
-        for (idx, each_param) in self.parameters.iter().enumerate() {
-            write!(f, "{}", each_param)?;
-            if idx != last_index {
-                write!(f, ", ")?;
-            }
-        }
-        write!(f, ")")?;
+        let params = self
+            .parameters
+            .iter()
+            .map(|each| each.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        write!(f, "({})", params)?;
         Ok(())
     }
 }

--- a/guard/src/rules/exprs.rs
+++ b/guard/src/rules/exprs.rs
@@ -370,8 +370,7 @@ impl<'loc> std::fmt::Display for FunctionExpr<'loc> {
             .map(|each| each.to_string())
             .collect::<Vec<_>>()
             .join(",");
-        write!(f, "({})", params)?;
-        Ok(())
+        write!(f, "({})", params)
     }
 }
 

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -1093,11 +1093,8 @@ fn call_expr(input: Span) -> IResult<Span, (String, Vec<LetValue>)> {
         var_name,
         delimited(
             char('('),
-            separated_nonempty_list(
-                char(','),
-                cut(delimited(multispace0, let_value, multispace0)),
-            ),
-            cut(char(')')),
+            separated_list(char(','), delimited(multispace0, let_value, multispace0)),
+            char(')'),
         ),
     ))(input)
 }
@@ -1715,13 +1712,10 @@ fn parameter_names(input: Span) -> IResult<Span, indexmap::IndexSet<String>> {
     delimited(
         char('('),
         map(
-            separated_nonempty_list(
-                char(','),
-                cut(delimited(multispace0, var_name, multispace0)),
-            ),
+            separated_list(char(','), delimited(multispace0, var_name, multispace0)),
             |v| v.into_iter().collect::<indexmap::IndexSet<String>>(),
         ),
-        cut(char(')')),
+        char(')'),
     )(input)
 }
 

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -1091,7 +1091,7 @@ fn function_expr(input: Span) -> IResult<Span, FunctionExpr> {
         input,
         FunctionExpr {
             location,
-            name: name.to_string(),
+            name,
             parameters,
         },
     ))
@@ -1734,10 +1734,13 @@ fn parameter_names(input: Span) -> IResult<Span, indexmap::IndexSet<String>> {
     delimited(
         char('('),
         map(
-            separated_list(char(','), delimited(multispace0, var_name, multispace0)),
+            separated_nonempty_list(
+                char(','),
+                cut(delimited(multispace0, var_name, multispace0)),
+            ),
             |v| v.into_iter().collect::<indexmap::IndexSet<String>>(),
         ),
-        char(')'),
+        cut(char(')')),
     )(input)
 }
 

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -3712,7 +3712,7 @@ fn rule_parameters_parse_test() -> Result<(), Error> {
     assert!(result.is_err());
     assert_eq!(
         result.err(),
-        Some(nom::Err::Error(ParserError {
+        Some(nom::Err::Failure(ParserError {
             // expect failure to not close
             kind: ErrorKind::Char, // no ')'
             context: "".to_string(),
@@ -3725,11 +3725,11 @@ fn rule_parameters_parse_test() -> Result<(), Error> {
     assert!(result.is_err());
     assert_eq!(
         result.err(),
-        Some(nom::Err::Error(ParserError {
+        Some(nom::Err::Failure(ParserError {
             // expect failure to not close
-            kind: ErrorKind::Char, // due to var_name
+            kind: ErrorKind::Alpha, // due to var_name
             context: "".to_string(),
-            span: unsafe { Span::new_from_raw_offset("(statements".len(), 1, ",)", "") }
+            span: unsafe { Span::new_from_raw_offset("(statements,".len(), 1, ")", "") }
         }))
     );
 
@@ -4317,7 +4317,7 @@ fn parameters_guard_clause_multiple() -> Result<(), Error> {
                     query: vec![QueryPart::Key("%var".to_string())],
                     match_all: true,
                 })],
-                name: "count".to_string(),
+                name: FunctionName::Count,
                 location: FileLocation {
                     line: 7,
                     column: 9,
@@ -4351,7 +4351,7 @@ fn parameterized_rule_single_param_function_with_one_argument() -> Result<(), Er
                 query: vec![QueryPart::Key("%var".to_string())],
                 match_all: true,
             })],
-            name: "count".to_string(),
+            name: FunctionName::Count,
             location: FileLocation {
                 line: 1,
                 column: 37,
@@ -4392,7 +4392,7 @@ fn parameterized_rule_single_param_function_with_multiple_arguments() -> Result<
                     "${1}/${4}/${3}/${2}-${5}".to_string(),
                 ))?),
             ],
-            name: "regex_replace".to_string(),
+            name: FunctionName::RegexReplace,
             location: FileLocation {
                 line: 1,
                 column: 37,
@@ -4527,7 +4527,7 @@ fn test_variable_capture_syntax() -> Result<(), Error> {
 fn test_builtin_function_call_expr() -> Result<(), Error> {
     let call_expr = "count(Resources.*)";
     let function = FunctionExpr::try_from(call_expr)?;
-    assert_eq!(function.name, "count");
+    assert_eq!(function.name, FunctionName::Count);
     assert_eq!(function.parameters.len(), 1);
     let parameter = &function.parameters[0];
     assert!(matches!(parameter, LetValue::AccessClause(_)));
@@ -4544,7 +4544,7 @@ fn test_builtin_function_call_expr() -> Result<(), Error> {
     let call_expr =
         r#"json_parse(Resources[ Type == 'AWS::SNS::TopicPolicy' ].Properties.PolicyDocument)"#;
     let function = FunctionExpr::try_from(call_expr)?;
-    assert_eq!(function.name, "json_parse");
+    assert_eq!(function.name, FunctionName::JsonParse);
     assert_eq!(function.parameters.len(), 1);
     let parameter = &function.parameters[0];
     assert!(matches!(parameter, LetValue::AccessClause(_)));
@@ -4556,7 +4556,7 @@ fn test_builtin_function_call_expr() -> Result<(), Error> {
     let call_expr =
         r#"json_parse(Resources[ Type == 'AWS::SNS::TopicPolicy' ].Properties.PolicyDocument)"#;
     let function = FunctionExpr::try_from(call_expr)?;
-    assert_eq!(function.name, "json_parse");
+    assert_eq!(function.name, FunctionName::JsonParse);
     assert_eq!(function.parameters.len(), 1);
     let parameter = &function.parameters[0];
     assert!(matches!(parameter, LetValue::AccessClause(_)));
@@ -4567,7 +4567,7 @@ fn test_builtin_function_call_expr() -> Result<(), Error> {
 
     let call_expr = r#"substring(%sqs_queues.Arn, 0, 6)"#;
     let function = FunctionExpr::try_from(call_expr)?;
-    assert_eq!(function.name, "substring");
+    assert_eq!(function.name, FunctionName::Substring);
     assert_eq!(function.parameters.len(), 3);
     let parameter = &function.parameters[0];
     assert!(matches!(parameter, LetValue::AccessClause(_)));
@@ -4662,7 +4662,7 @@ fn test_parse_assignment_with_function_call() {
     assert!(matches!(function, LetValue::FunctionCall(_)));
 
     if let LetValue::FunctionCall(function) = function {
-        assert_eq!(function.name, "count");
+        assert_eq!(function.name, FunctionName::Count);
         assert_eq!(function.parameters.len(), 1);
         assert!(matches!(function.parameters[0], LetValue::AccessClause(_)));
     }
@@ -4679,7 +4679,7 @@ fn test_parse_assignment_with_function_call2() {
     assert!(matches!(function, LetValue::FunctionCall(_)));
 
     if let LetValue::FunctionCall(function) = function {
-        assert_eq!(function.name, "regex_replace");
+        assert_eq!(function.name, FunctionName::RegexReplace);
         assert_eq!(function.parameters.len(), 3);
         assert!(matches!(
             function.parameters[1],

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -3694,17 +3694,6 @@ fn rule_parameters_parse_test() -> Result<(), Error> {
     //
     // Error cases
     //
-    let parameters = "()";
-    let result = parameter_names(from_str2(parameters));
-    assert!(result.is_err());
-    assert_eq!(
-        result.err(),
-        Some(nom::Err::Failure(ParserError {
-            context: "".to_string(),
-            kind: ErrorKind::Alpha, // for var_name
-            span: unsafe { Span::new_from_raw_offset(1, 1, ")", "") }
-        }))
-    );
 
     let parameters = "statements";
     let result = parameter_names(from_str2(parameters));

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -3712,7 +3712,7 @@ fn rule_parameters_parse_test() -> Result<(), Error> {
     assert!(result.is_err());
     assert_eq!(
         result.err(),
-        Some(nom::Err::Failure(ParserError {
+        Some(nom::Err::Error(ParserError {
             // expect failure to not close
             kind: ErrorKind::Char, // no ')'
             context: "".to_string(),
@@ -3725,11 +3725,11 @@ fn rule_parameters_parse_test() -> Result<(), Error> {
     assert!(result.is_err());
     assert_eq!(
         result.err(),
-        Some(nom::Err::Failure(ParserError {
+        Some(nom::Err::Error(ParserError {
             // expect failure to not close
-            kind: ErrorKind::Alpha, // due to var_name
+            kind: ErrorKind::Char, // due to var_name
             context: "".to_string(),
-            span: unsafe { Span::new_from_raw_offset("(statements,".len(), 1, ")", "") }
+            span: unsafe { Span::new_from_raw_offset("(statements".len(), 1, ",)", "") }
         }))
     );
 


### PR DESCRIPTION
*Issue #, if available:* None


*Description of changes:*

Uses and enum instead of hardcoded strings for function names, allows for function invocation without arguments, and allows for optional arguments in a function.
---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
